### PR TITLE
update to latest master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -20,7 +20,7 @@ const pkgs = struct {
 
 fn initNativeLibrary(lib: *std.build.LibExeObjStep, mode: std.builtin.Mode, target: std.zig.CrossTarget) void {
     lib.addPackage(pkgs.tvg);
-    lib.addIncludeDir("src/binding/include");
+    lib.addIncludePath("src/binding/include");
     lib.setBuildMode(mode);
     lib.setTarget(target);
     lib.bundle_compiler_rt = true;
@@ -129,14 +129,14 @@ pub fn build(b: *std.build.Builder) !void {
         const static_binding_test = b.addExecutable("static-native-binding", null);
         static_binding_test.setBuildMode(mode);
         static_binding_test.linkLibC();
-        static_binding_test.addIncludeDir("src/binding/include");
+        static_binding_test.addIncludePath("src/binding/include");
         static_binding_test.addCSourceFile("examples/usage.c", &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99" });
         static_binding_test.linkLibrary(static_native_lib);
 
         const dynamic_binding_test = b.addExecutable("static-native-binding", null);
         dynamic_binding_test.setBuildMode(mode);
         dynamic_binding_test.linkLibC();
-        dynamic_binding_test.addIncludeDir("src/binding/include");
+        dynamic_binding_test.addIncludePath("src/binding/include");
         dynamic_binding_test.addCSourceFile("examples/usage.c", &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99" });
         dynamic_binding_test.linkLibrary(dynamic_native_lib);
 

--- a/src/data/ground-truth.zig
+++ b/src/data/ground-truth.zig
@@ -271,7 +271,7 @@ pub fn writeEverything(src_writer: anytype, range: tvg.Range) !void {
     for (style_base) |style_example| {
         var dy: f32 = padding;
 
-        for (items) |item| {
+        inline for (items) |item| {
             var style = style_example;
             switch (style) {
                 .flat => {},


### PR DESCRIPTION
Changes:

  - switch to newer`std.build.Builder` APIs as zig master has made some old ones a `@compileError()`
  - fix pointless discard (also addressed by #10)
  - inline the `for` loop over the `Emitter` functions in due to compiler complaining that `items`  but be comptime, another fix is probably to change the type of `items` to `[10]*const fn(...)`

I've marked this a draft as compiling with latest master would also require updating the parser-toolkit dependency with [this PR](https://github.com/MasterQ32/parser-toolkit/pull/1) and this dependency update could be bundled with this PR.