### PR TITLE
always use a pointer to first arg for struct member functions

### DIFF
--- a/src/lib/parsing.zig
+++ b/src/lib/parsing.zig
@@ -457,7 +457,7 @@ pub fn Parser(comptime Reader: type) type {
             };
         }
 
-        fn readNode(self: Self) !Path.Node {
+        fn readNode(self: *Self) !Path.Node {
             const Tag = packed struct {
                 type: Path.Type,
                 padding0: u1 = 0,
@@ -534,7 +534,7 @@ pub fn Parser(comptime Reader: type) type {
             };
         }
 
-        fn readStyle(self: Self, kind: StyleType) !Style {
+        fn readStyle(self: *Self, kind: StyleType) !Style {
             return switch (kind) {
                 .flat => Style{ .flat = try self.readUInt() },
                 .linear => Style{ .linear = try self.readGradient() },
@@ -542,7 +542,7 @@ pub fn Parser(comptime Reader: type) type {
             };
         }
 
-        fn readGradient(self: Self) !Gradient {
+        fn readGradient(self: *Self) !Gradient {
             var grad: Gradient = undefined;
             grad.point_0 = Point{
                 .x = try self.readUnit(),
@@ -563,7 +563,7 @@ pub fn Parser(comptime Reader: type) type {
             return grad;
         }
 
-        fn readUInt(self: Self) error{InvalidData}!u32 {
+        fn readUInt(self: *Self) error{InvalidData}!u32 {
             var byte_count: u8 = 0;
             var result: u32 = 0;
             while (true) {
@@ -581,7 +581,7 @@ pub fn Parser(comptime Reader: type) type {
             return result;
         }
 
-        fn readUnit(self: Self) !f32 {
+        fn readUnit(self: *const Self) !f32 {
             switch (self.header.coordinate_range) {
                 .reduced => return @intToEnum(tvg.Unit, try self.reader.readIntLittle(i8)).toFloat(self.header.scale),
                 .default => return @intToEnum(tvg.Unit, try self.reader.readIntLittle(i16)).toFloat(self.header.scale),
@@ -589,11 +589,11 @@ pub fn Parser(comptime Reader: type) type {
             }
         }
 
-        fn readByte(self: Self) !u8 {
+        fn readByte(self: *Self) !u8 {
             return try self.reader.readByte();
         }
 
-        fn readU16(self: Self) !u16 {
+        fn readU16(self: *Self) !u16 {
             return try self.reader.readIntLittle(u16);
         }
     };
@@ -604,11 +604,11 @@ const CountAndStyleTag = packed struct {
     raw_count: u6,
     style_kind: u2,
 
-    pub fn getCount(self: Self) usize {
+    pub fn getCount(self: *const Self) usize {
         return @as(usize, self.raw_count) + 1;
     }
 
-    pub fn getStyleType(self: Self) !StyleType {
+    pub fn getStyleType(self: *const Self) !StyleType {
         return convertStyleType(self.style_kind);
     }
 };

--- a/src/lib/rendering.zig
+++ b/src/lib/rendering.zig
@@ -176,7 +176,7 @@ const Framebuffer = struct {
     width: usize,
     height: usize,
 
-    pub fn setPixel(self: Self, x: isize, y: isize, src_color: tvg.Color) void {
+    pub fn setPixel(self: *const Self, x: isize, y: isize, src_color: tvg.Color) void {
         if (x < 0 or y < 0)
             return;
         if (x >= self.width or y >= self.height)
@@ -1196,14 +1196,14 @@ pub fn FixedBufferList(comptime T: type, comptime N: usize) type {
             return self.buffer[0..self.count];
         }
 
-        pub fn items(self: Self) []const T {
+        pub fn items(self: *const Self) []const T {
             if (self.large) |*large| {
                 return large.items;
             }
             return self.buffer[0..self.count];
         }
 
-        pub fn front(self: Self) ?T {
+        pub fn front(self: *const Self) ?T {
             if (self.large) |*large| {
                 if (large.items.len > 0) {
                     return large.items[0];
@@ -1216,7 +1216,7 @@ pub fn FixedBufferList(comptime T: type, comptime N: usize) type {
             return self.buffer[0];
         }
 
-        pub fn back(self: Self) ?T {
+        pub fn back(self: *const Self) ?T {
             if (self.large) |*large| {
                 if (large.items.len > 0) {
                     return large.items[large.items.len - 1];

--- a/src/lib/tinyvg.zig
+++ b/src/lib/tinyvg.zig
@@ -145,15 +145,15 @@ pub const Scale = enum(u4) {
     @"1/16384" = 14,
     @"1/32768" = 15,
 
-    pub fn map(self: Self, value: f32) Unit {
-        return Unit.init(self, value);
+    pub fn map(self: *const Self, value: f32) Unit {
+        return Unit.init(self.*, value);
     }
 
-    pub fn getShiftBits(self: Self) u4 {
-        return @enumToInt(self);
+    pub fn getShiftBits(self: *const Self) u4 {
+        return @enumToInt(self.*);
     }
 
-    pub fn getScaleFactor(self: Self) u15 {
+    pub fn getScaleFactor(self: *const Self) u15 {
         return @as(u15, 1) << self.getShiftBits();
     }
 };
@@ -168,20 +168,20 @@ pub const Unit = enum(i32) {
         return @intToEnum(Self, @floatToInt(i32, value * @intToFloat(f32, scale.getScaleFactor()) + 0.5));
     }
 
-    pub fn raw(self: Self) i32 {
-        return @enumToInt(self);
+    pub fn raw(self: *const Self) i32 {
+        return @enumToInt(self.*);
     }
 
-    pub fn toFloat(self: Self, scale: Scale) f32 {
-        return @intToFloat(f32, @enumToInt(self)) / @intToFloat(f32, scale.getScaleFactor());
+    pub fn toFloat(self: *const Self, scale: Scale) f32 {
+        return @intToFloat(f32, @enumToInt(self.*)) / @intToFloat(f32, scale.getScaleFactor());
     }
 
-    pub fn toInt(self: Self, scale: Scale) i32 {
+    pub fn toInt(self: *const Self, scale: Scale) i32 {
         const factor = scale.getScaleFactor();
-        return @divFloor(@enumToInt(self) + (@divExact(factor, 2)), factor);
+        return @divFloor(@enumToInt(self.*) + (@divExact(factor, 2)), factor);
     }
 
-    pub fn toUnsignedInt(self: Self, scale: Scale) !u31 {
+    pub fn toUnsignedInt(self: *const Self, scale: Scale) !u31 {
         const i = toInt(self, scale);
         if (i < 0)
             return error.InvalidData;
@@ -197,7 +197,7 @@ pub const Color = extern struct {
     b: f32,
     a: f32,
 
-    pub fn toRgba8(self: Self) [4]u8 {
+    pub fn toRgba8(self: *const Self) [4]u8 {
         return [4]u8{
             @floatToInt(u8, std.math.clamp(255.0 * self.r, 0.0, 255.0)),
             @floatToInt(u8, std.math.clamp(255.0 * self.g, 0.0, 255.0)),


### PR DESCRIPTION
This fixes some rendering problems I encountered using zig stage2.

See https://github.com/ziglang/zig/issues/13244 which was me trying to figure out the bug.  Also https://github.com/ziglang/zig/issues/13249 which has more explanation.