### PR TITLE
Update for recent Zig 0.12, use .NET 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: v0.11.0
+          version: master
 
       - name: Install dotnet sdk
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: Compile Tools
         run: zig build install

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ This SDK enables you to work with the [TinyVG](https://tinyvg.tech/) vector grap
 
 ## Building
 
-The SDK is implemented with [Zig](https://ziglang.org/) 0.11.0 and [dotnet 5](https://dotnet.microsoft.com/en-us/).
+The SDK is implemented with [Zig](https://ziglang.org/) 0.12.0 and [dotnet 6](https://dotnet.microsoft.com/en-us/).
 
 To build the SDK (except `svg2tvgt`), do this:
 
 ```sh-session
+[user@host sdk]$ cd src/tools/svg2tvgt/
 [user@host sdk]$ zig build
 [user@host sdk]$
 ```
@@ -26,21 +27,18 @@ This will then produce the folders `zig-cache` (for temporary files) and `zig-ou
 To build `svg2tvgt`, go into the folder `src/tools/svg2tvgt` and do this:
 
 ```sh-session
-[user@host sdk]$ cd src/tools/svg2tvgt/
 [user@host svg2tvgt]$ dotnet build
-Microsoft (R) Build Engine version 16.11.1+3e40a09f8 for .NET
-Copyright (C) Microsoft Corporation. All rights reserved.
-
+MSBuild version 17.3.2+561848881 for .NET
   Determining projects to restore...
   All projects are up-to-date for restore.
-  svg2tvgt -> /mnt/src/tools/svg2tvgt/bin/Debug/net5.0/svg2tvgt.dll
+  svg2tvgt -> /mnt/src/tools/svg2tvgt/bin/Debug/net6.0/svg2tvgt.dll
 
 Build succeeded.
     0 Warning(s)
     0 Error(s)
 
-Time Elapsed 00:00:01.59
+Time Elapsed 00:00:00.69
 [user@host svg2tvgt]$
 ```
 
-This will then produce `src/tools/svg2tvgt/bin/Debug/net5.0/svg2tvgt` (or `.exe` if you are on windows).
+This will then produce `src/tools/svg2tvgt/bin/Debug/net6.0/svg2tvgt` (or `.exe` if you are on windows).

--- a/build.zig
+++ b/build.zig
@@ -96,7 +96,7 @@ pub fn build(b: *std.Build) !void {
     }
 
     const generate_ground_truth = b.addRunArtifact(ground_truth_generator);
-    generate_ground_truth.cwd = b.cache_root.path;
+    generate_ground_truth.cwd = .{ .cwd_relative = b.cache_root.path.? };
 
     const gen_gt_step = b.step("generate", "Regenerates the ground truth data.");
 
@@ -111,14 +111,14 @@ pub fn build(b: *std.Build) !void {
         tvg_conversion.addArg("2");
         tvg_conversion.addArg("--output");
         tvg_conversion.addArg(file[0 .. file.len - 3] ++ "tga");
-        tvg_conversion.cwd = b.cache_root.path;
+        tvg_conversion.cwd = .{ .cwd_relative = b.cache_root.path.? };
         tvg_conversion.step.dependOn(&generate_ground_truth.step);
 
         const tvgt_conversion = b.addRunArtifact(text);
         tvgt_conversion.addArg(file);
         tvgt_conversion.addArg("--output");
         tvgt_conversion.addArg(file[0 .. file.len - 3] ++ "tvgt");
-        tvgt_conversion.cwd = b.cache_root.path;
+        tvgt_conversion.cwd = .{ .cwd_relative = b.cache_root.path.? };
         tvgt_conversion.step.dependOn(&generate_ground_truth.step);
 
         gen_gt_step.dependOn(&tvgt_conversion.step);
@@ -154,10 +154,10 @@ pub fn build(b: *std.Build) !void {
         dynamic_binding_test.linkLibrary(dynamic_native_lib);
 
         const static_binding_test_run = b.addRunArtifact(static_binding_test);
-        static_binding_test_run.cwd = b.cache_root.path;
+        static_binding_test_run.cwd = .{ .cwd_relative = b.cache_root.path.? };
 
         const dynamic_binding_test_run = b.addRunArtifact(dynamic_binding_test);
-        dynamic_binding_test_run.cwd = b.cache_root.path;
+        dynamic_binding_test_run.cwd = .{ .cwd_relative = b.cache_root.path.? };
 
         const test_step = b.step("test", "Runs all tests");
         test_step.dependOn(&b.addRunArtifact(tvg_tests).step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,14 +1,15 @@
 .{
     .name = "tinyvg",
     .version = "0.0.1",
+    .paths = .{""},
     .dependencies = .{
         .args = .{
-            .url = "https://github.com/MasterQ32/zig-args/archive/91d1e89fb89a4d01dec7c9aec95b0a324080ebcc.tar.gz",
-            .hash = "12203d04cafc97f952d74cdb077e74c0ab3414f9f6b5fbd159112c62bfa584a0dbed",
+            .url = "https://github.com/MasterQ32/zig-args/archive/3797c1473b48e445d721d40c8fbbe9a7422095ae.tar.gz",
+            .hash = "122012fa395ee8ac94592f3a535ed3899a4485e96ee3d4ec8f82c761bf304b34b870",
         },
         .ptk = .{
-            .url = "https://github.com/MasterQ32/parser-toolkit/archive/6238b7c6893582fb56f39676a090b1af1226fe1a.tar.gz",
-            .hash = "1220cf55c10add71a9cd2591dbe118ffa9a9198e21069e440fae1f6e3eef6f274733",
+            .url = "https://github.com/MasterQ32/parser-toolkit/archive/5416f1ff721cbfbf91397e557fc400e004804361.tar.gz",
+            .hash = "12207450343aa027d9478b85b67b2f390360851d17dbf00e95376d133140276479c2",
         },
     },
 }

--- a/src/binding/binding.zig
+++ b/src/binding/binding.zig
@@ -16,7 +16,7 @@ fn renderBitmap(data: []const u8, src_anti_alias: c.tinyvg_AntiAlias, width: u32
     var temp_mem = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer temp_mem.deinit();
 
-    var size_hint: tvg.rendering.SizeHint = if (width == 0 and height == 0)
+    const size_hint: tvg.rendering.SizeHint = if (width == 0 and height == 0)
         .inherit
     else if (width == 0)
         tvg.rendering.SizeHint{ .height = height }
@@ -24,7 +24,7 @@ fn renderBitmap(data: []const u8, src_anti_alias: c.tinyvg_AntiAlias, width: u32
         tvg.rendering.SizeHint{ .width = width }
     else
         tvg.rendering.SizeHint{ .size = .{ .width = width, .height = height } };
-    var anti_alias: tvg.rendering.AntiAliasing = @enumFromInt(src_anti_alias);
+    const anti_alias: tvg.rendering.AntiAliasing = @enumFromInt(src_anti_alias);
 
     var image = try tvg.rendering.renderBuffer(
         temp_mem.allocator(),

--- a/src/lib/builder.zig
+++ b/src/lib/builder.zig
@@ -52,21 +52,21 @@ pub fn Builder(comptime Writer: type) type {
                     const rwidth = mapSizeToType(u8, width) catch return error.OutOfRange;
                     const rheight = mapSizeToType(u8, height) catch return error.OutOfRange;
 
-                    try self.writer.writeIntLittle(u8, rwidth);
-                    try self.writer.writeIntLittle(u8, rheight);
+                    try self.writer.writeInt(u8, rwidth, .little);
+                    try self.writer.writeInt(u8, rheight, .little);
                 },
 
                 .default => {
                     const rwidth = mapSizeToType(u16, width) catch return error.OutOfRange;
                     const rheight = mapSizeToType(u16, height) catch return error.OutOfRange;
 
-                    try self.writer.writeIntLittle(u16, rwidth);
-                    try self.writer.writeIntLittle(u16, rheight);
+                    try self.writer.writeInt(u16, rwidth, .little);
+                    try self.writer.writeInt(u16, rheight, .little);
                 },
 
                 .enhanced => {
-                    try self.writer.writeIntLittle(u32, width);
-                    try self.writer.writeIntLittle(u32, height);
+                    try self.writer.writeInt(u32, width, .little);
+                    try self.writer.writeInt(u32, height, .little);
                 },
             }
 
@@ -93,21 +93,21 @@ pub fn Builder(comptime Writer: type) type {
                         (@as(u16, ((rgb8[1] >> 2) & 0x2F)) << 5) |
                         (@as(u16, ((rgb8[2] >> 3) & 0x1F)) << 11);
 
-                    try self.writer.writeIntLittle(u16, value);
+                    try self.writer.writeInt(u16, value, .little);
                 },
 
                 .u8888 => for (colors) |c| {
-                    var rgba = c.toRgba8();
-                    try self.writer.writeIntLittle(u8, rgba[0]);
-                    try self.writer.writeIntLittle(u8, rgba[1]);
-                    try self.writer.writeIntLittle(u8, rgba[2]);
-                    try self.writer.writeIntLittle(u8, rgba[3]);
+                    const rgba = c.toRgba8();
+                    try self.writer.writeInt(u8, rgba[0], .little);
+                    try self.writer.writeInt(u8, rgba[1], .little);
+                    try self.writer.writeInt(u8, rgba[2], .little);
+                    try self.writer.writeInt(u8, rgba[3], .little);
                 },
                 .f32 => for (colors) |c| {
-                    try self.writer.writeIntLittle(u32, @as(u32, @bitCast(c.r)));
-                    try self.writer.writeIntLittle(u32, @as(u32, @bitCast(c.g)));
-                    try self.writer.writeIntLittle(u32, @as(u32, @bitCast(c.b)));
-                    try self.writer.writeIntLittle(u32, @as(u32, @bitCast(c.a)));
+                    try self.writer.writeInt(u32, @as(u32, @bitCast(c.r)), .little);
+                    try self.writer.writeInt(u32, @as(u32, @bitCast(c.g)), .little);
+                    try self.writer.writeInt(u32, @as(u32, @bitCast(c.b)), .little);
+                    try self.writer.writeInt(u32, @as(u32, @bitCast(c.a)), .little);
                 },
 
                 .custom => return error.UnsupportedColorEncoding,
@@ -357,14 +357,14 @@ pub fn Builder(comptime Writer: type) type {
             switch (self.range) {
                 .reduced => {
                     const reduced_val = std.math.cast(i8, val) orelse return error.OutOfRange;
-                    try self.writer.writeIntLittle(i8, reduced_val);
+                    try self.writer.writeInt(i8, reduced_val, .little);
                 },
                 .default => {
                     const reduced_val = std.math.cast(i16, val) orelse return error.OutOfRange;
-                    try self.writer.writeIntLittle(i16, reduced_val);
+                    try self.writer.writeInt(i16, reduced_val, .little);
                 },
                 .enhanced => {
-                    try self.writer.writeIntLittle(i32, val);
+                    try self.writer.writeInt(i32, val, .little);
                 },
             }
         }

--- a/src/lib/data/ground-truth.zig
+++ b/src/lib/data/ground-truth.zig
@@ -241,7 +241,7 @@ pub fn writeEverything(src_writer: anytype, range: tvg.Range) !void {
         Emitter.emitOutlineFillPath,
     };
 
-    var style_base = [_]tvg.Style{
+    const style_base = [_]tvg.Style{
         tvg.Style{ .flat = 0 },
         tvg.Style{ .linear = .{
             .point_0 = tvg.point(0, 0),

--- a/src/lib/parsing.zig
+++ b/src/lib/parsing.zig
@@ -141,14 +141,14 @@ pub fn Parser(comptime Reader: type) type {
                     const range: tvg.Range = @enumFromInt(scale_and_flags.coordinate_range);
 
                     const width: u32 = switch (range) {
-                        .reduced => mapZeroToMax(try reader.readIntLittle(u8)),
-                        .default => mapZeroToMax(try reader.readIntLittle(u16)),
-                        .enhanced => std.math.cast(u32, mapZeroToMax(try reader.readIntLittle(u32))) orelse return error.InvalidData,
+                        .reduced => mapZeroToMax(try reader.readInt(u8, .little)),
+                        .default => mapZeroToMax(try reader.readInt(u16, .little)),
+                        .enhanced => std.math.cast(u32, mapZeroToMax(try reader.readInt(u32, .little))) orelse return error.InvalidData,
                     };
                     const height: u32 = switch (range) {
-                        .reduced => mapZeroToMax(try reader.readIntLittle(u8)),
-                        .default => mapZeroToMax(try reader.readIntLittle(u16)),
-                        .enhanced => std.math.cast(u32, mapZeroToMax(try reader.readIntLittle(u32))) orelse return error.InvalidData,
+                        .reduced => mapZeroToMax(try reader.readInt(u8, .little)),
+                        .default => mapZeroToMax(try reader.readInt(u16, .little)),
+                        .enhanced => std.math.cast(u32, mapZeroToMax(try reader.readInt(u32, .little))) orelse return error.InvalidData,
                     };
 
                     const color_count = try self.readUInt();
@@ -159,13 +159,13 @@ pub fn Parser(comptime Reader: type) type {
                     for (self.color_table) |*c| {
                         c.* = switch (color_encoding) {
                             .u8888 => tvg.Color{
-                                .r = @as(f32, @floatFromInt(try reader.readIntLittle(u8))) / 255.0,
-                                .g = @as(f32, @floatFromInt(try reader.readIntLittle(u8))) / 255.0,
-                                .b = @as(f32, @floatFromInt(try reader.readIntLittle(u8))) / 255.0,
-                                .a = @as(f32, @floatFromInt(try reader.readIntLittle(u8))) / 255.0,
+                                .r = @as(f32, @floatFromInt(try reader.readInt(u8, .little))) / 255.0,
+                                .g = @as(f32, @floatFromInt(try reader.readInt(u8, .little))) / 255.0,
+                                .b = @as(f32, @floatFromInt(try reader.readInt(u8, .little))) / 255.0,
+                                .a = @as(f32, @floatFromInt(try reader.readInt(u8, .little))) / 255.0,
                             },
                             .u565 => blk: {
-                                const rgb = try reader.readIntLittle(u16);
+                                const rgb = try reader.readInt(u16, .little);
                                 break :blk tvg.Color{
                                     .r = @as(f32, @floatFromInt((rgb & 0x001F) >> 0)) / 31.0,
                                     .g = @as(f32, @floatFromInt((rgb & 0x07E0) >> 5)) / 63.0,
@@ -175,10 +175,10 @@ pub fn Parser(comptime Reader: type) type {
                             },
                             .f32 => tvg.Color{
                                 // TODO: Verify if this is platform independently correct:
-                                .r = @as(f32, @bitCast(try reader.readIntLittle(u32))),
-                                .g = @as(f32, @bitCast(try reader.readIntLittle(u32))),
-                                .b = @as(f32, @bitCast(try reader.readIntLittle(u32))),
-                                .a = @as(f32, @bitCast(try reader.readIntLittle(u32))),
+                                .r = @as(f32, @bitCast(try reader.readInt(u32, .little))),
+                                .g = @as(f32, @bitCast(try reader.readInt(u32, .little))),
+                                .b = @as(f32, @bitCast(try reader.readInt(u32, .little))),
+                                .a = @as(f32, @bitCast(try reader.readInt(u32, .little))),
                             },
                             .custom => return error.UnsupportedColorFormat,
                         };
@@ -210,7 +210,7 @@ pub fn Parser(comptime Reader: type) type {
             // alignment here
             try self.temp_buffer.resize(@sizeOf(T) * length);
 
-            var items = std.mem.bytesAsSlice(T, self.temp_buffer.items[0..(@sizeOf(T) * length)]);
+            const items = std.mem.bytesAsSlice(T, self.temp_buffer.items[0..(@sizeOf(T) * length)]);
             std.debug.assert(items.len == length);
             return items;
         }
@@ -229,7 +229,7 @@ pub fn Parser(comptime Reader: type) type {
             // T2 alignment could be larger than T1
             const offset = std.mem.alignForward(usize, @sizeOf(T1) * length1, @alignOf(T2));
 
-            var result = .{
+            const result = .{
                 .first = std.mem.bytesAsSlice(T1, self.temp_buffer.items[0 .. @sizeOf(T1) * length1]),
                 .second = @as([]T2, @alignCast(std.mem.bytesAsSlice(T2, self.temp_buffer.items[offset..][0 .. @sizeOf(T2) * length2]))),
             };
@@ -447,7 +447,7 @@ pub fn Parser(comptime Reader: type) type {
                 segment.start.x = try self.readUnit();
                 segment.start.y = try self.readUnit();
 
-                var commands = buffers.second[segment_start..][0..segment_len];
+                const commands = buffers.second[segment_start..][0..segment_len];
                 for (commands) |*node| {
                     node.* = try self.readNode();
                 }
@@ -472,7 +472,7 @@ pub fn Parser(comptime Reader: type) type {
             };
             const tag: Tag = @bitCast(try self.readByte());
 
-            var line_width: ?f32 = if (tag.has_line_width)
+            const line_width: ?f32 = if (tag.has_line_width)
                 try self.readUnit()
             else
                 null;
@@ -501,7 +501,7 @@ pub fn Parser(comptime Reader: type) type {
                     },
                 }) },
                 .arc_circle => blk: {
-                    var flags = try self.readByte();
+                    const flags = try self.readByte();
                     break :blk PathNode{ .arc_circle = PathNode.NodeData(PathNode.ArcCircle).init(line_width, PathNode.ArcCircle{
                         .radius = try self.readUnit(),
                         .large_arc = (flags & 1) != 0,
@@ -513,7 +513,7 @@ pub fn Parser(comptime Reader: type) type {
                     }) };
                 },
                 .arc_ellipse => blk: {
-                    var flags = try self.readByte();
+                    const flags = try self.readByte();
                     break :blk PathNode{ .arc_ellipse = PathNode.NodeData(PathNode.ArcEllipse).init(line_width, PathNode.ArcEllipse{
                         .radius_x = try self.readUnit(),
                         .radius_y = try self.readUnit(),
@@ -589,9 +589,9 @@ pub fn Parser(comptime Reader: type) type {
 
         fn readUnit(self: *const Self) !f32 {
             const unit: tvg.Unit = switch (self.header.coordinate_range) {
-                .reduced => @enumFromInt(try self.reader.readIntLittle(i8)),
-                .default => @enumFromInt(try self.reader.readIntLittle(i16)),
-                .enhanced => @enumFromInt(try self.reader.readIntLittle(i32)),
+                .reduced => @enumFromInt(try self.reader.readInt(i8, .little)),
+                .default => @enumFromInt(try self.reader.readInt(i16, .little)),
+                .enhanced => @enumFromInt(try self.reader.readInt(i32, .little)),
             };
             return unit.toFloat(self.header.scale);
         }
@@ -601,11 +601,10 @@ pub fn Parser(comptime Reader: type) type {
         }
 
         fn readU16(self: *Self) !u16 {
-            return try self.reader.readIntLittle(u16);
+            return try self.reader.readInt(u16, .little);
         }
     };
 }
-
 const CountAndStyleTag = packed struct {
     const Self = @This();
     raw_count: u6,

--- a/src/lib/rendering.zig
+++ b/src/lib/rendering.zig
@@ -89,7 +89,7 @@ pub fn renderStream(
         try renderCommand(&framebuffer, parser.header, parser.color_table, cmd, temporary_allocator);
     }
 
-    var image = Image{
+    const image = Image{
         .pixels = try image_allocator.alloc(Color8, target_pixel_count),
         .width = target_size.width,
         .height = target_size.height,
@@ -260,9 +260,9 @@ pub fn isFramebuffer(comptime T: type) bool {
         std.meta.Child(T)
     else
         T;
-    return std.meta.trait.hasFn("setPixel")(FbType) and
-        std.meta.trait.hasField("width")(FbType) and
-        std.meta.trait.hasField("height")(FbType);
+    return std.meta.hasFn(FbType, "setPixel") and
+        @hasField(FbType, "width") and
+        @hasField(FbType, "height");
 }
 
 const Point = tvg.Point;
@@ -412,10 +412,10 @@ pub fn renderCommand(
         .outline_fill_rectangles => |data| {
             for (data.rectangles) |rect| {
                 painter.fillRectangle(framebuffer, rect.x, rect.y, rect.width, rect.height, color_table, data.fill_style);
-                var tl = Point{ .x = rect.x, .y = rect.y };
-                var tr = Point{ .x = rect.x + rect.width, .y = rect.y };
-                var bl = Point{ .x = rect.x, .y = rect.y + rect.height };
-                var br = Point{ .x = rect.x + rect.width, .y = rect.y + rect.height };
+                const tl = Point{ .x = rect.x, .y = rect.y };
+                const tr = Point{ .x = rect.x + rect.width, .y = rect.y };
+                const bl = Point{ .x = rect.x, .y = rect.y + rect.height };
+                const br = Point{ .x = rect.x + rect.width, .y = rect.y + rect.height };
                 painter.drawLine(framebuffer, color_table, data.line_style, data.line_width, data.line_width, .{ .start = tl, .end = tr });
                 painter.drawLine(framebuffer, color_table, data.line_style, data.line_width, data.line_width, .{ .start = tr, .end = br });
                 painter.drawLine(framebuffer, color_table, data.line_style, data.line_width, data.line_width, .{ .start = br, .end = bl });
@@ -527,7 +527,7 @@ pub fn renderPath(
                 .horiz => |x| try point_store.append(Point{ .x = x.data, .y = point_store.back().y }, x.line_width orelse last_width),
                 .vert => |y| try point_store.append(Point{ .x = point_store.back().x, .y = y.data }, y.line_width orelse last_width),
                 .bezier => |bezier| {
-                    var previous = point_store.back();
+                    const previous = point_store.back();
 
                     const oct0_x = [4]f32{ previous.x, bezier.data.c0.x, bezier.data.c1.x, bezier.data.p1.x };
                     const oct0_y = [4]f32{ previous.y, bezier.data.c0.y, bezier.data.c1.y, bezier.data.p1.y };
@@ -544,7 +544,7 @@ pub fn renderPath(
                     try point_store.append(bezier.data.p1, new_width);
                 },
                 .quadratic_bezier => |bezier| {
-                    var previous = point_store.back();
+                    const previous = point_store.back();
 
                     const oct0_x = [3]f32{ previous.x, bezier.data.c.x, bezier.data.p1.x };
                     const oct0_y = [3]f32{ previous.y, bezier.data.c.y, bezier.data.p1.y };
@@ -626,9 +626,6 @@ inline fn sin(val: anytype) @TypeOf(val) {
 }
 inline fn sqrt(val: anytype) @TypeOf(val) {
     return @sqrt(val);
-}
-inline fn abs(val: anytype) @TypeOf(val) {
-    return @fabs(val);
 }
 
 pub fn renderEllipse(
@@ -745,7 +742,7 @@ fn renderCircle(
     const angle = std.math.asin(std.math.clamp(sqrt(len_squared) / r, -1.0, 1.0)) * 2;
     const arc = if (large_arc) (std.math.tau - angle) else angle;
 
-    var pos = sub(p0, center);
+    const pos = sub(p0, center);
     for (0..circle_divs - 1) |i| {
         const step_mat = rotationMat(@as(f32, @floatFromInt(i)) * (if (turn_left) -arc else arc) / circle_divs);
         const point = add(applyMat(step_mat, pos), center);
@@ -857,9 +854,9 @@ fn distance(p1: Point, p2: Point) f32 {
 }
 
 fn getProjectedPointOnLine(v1: Point, v2: Point, p: Point) Point {
-    var l1 = sub(v2, v1);
-    var l2 = sub(p, v1);
-    var proj = dot(l1, l2) / length2(l1);
+    const l1 = sub(v2, v1);
+    const l2 = sub(p, v1);
+    const proj = dot(l1, l2) / length2(l1);
 
     return add(v1, scale(l1, proj));
 }
@@ -904,7 +901,7 @@ const Painter = struct {
             while (x <= max_x) : (x += 1) {
 
                 // compute "center" of the pixel
-                var p = self.mapPointToImage(pointFromInts(x, y));
+                const p = self.mapPointToImage(pointFromInts(x, y));
 
                 var inside_count: usize = 0;
                 for (points_lists) |points| {
@@ -958,7 +955,7 @@ const Painter = struct {
 
         //-----------
 
-        q.x = @fabs(q.x);
+        q.x = @abs(q.x);
 
         const b = ra - rb;
         const c = tvg.point(@sqrt(h - b * b), b);
@@ -1030,7 +1027,7 @@ const Painter = struct {
             while (x <= max_x) : (x += 1) {
 
                 // compute "center" of the pixel
-                var p = self.mapPointToImage(pointFromInts(x, y));
+                const p = self.mapPointToImage(pointFromInts(x, y));
 
                 const dist = sdUnevenCapsule(
                     p,

--- a/src/lib/svg.zig
+++ b/src/lib/svg.zig
@@ -148,24 +148,24 @@ pub fn renderStream(allocator: std.mem.Allocator, parser: anytype, writer: anyty
             },
 
             .draw_line_path => |data| {
-                var style = svgStyle(&cache, null, data.style, data.line_width);
-                var path = SvgPath{ .path = data.path };
+                const style = svgStyle(&cache, null, data.style, data.line_width);
+                const path = SvgPath{ .path = data.path };
                 try writer.print(
                     \\<path style="{}" d="{}"/>
                 , .{ style, path });
             },
 
             .fill_path => |data| {
-                var style = svgStyle(&cache, data.style, null, null);
-                var path = SvgPath{ .path = data.path };
+                const style = svgStyle(&cache, data.style, null, null);
+                const path = SvgPath{ .path = data.path };
                 try writer.print(
                     \\<path style="{}" d="{}"/>
                 , .{ style, path });
             },
 
             .outline_fill_path => |data| {
-                var style = svgStyle(&cache, data.fill_style, data.line_style, data.line_width);
-                var path = SvgPath{ .path = data.path };
+                const style = svgStyle(&cache, data.fill_style, data.line_style, data.line_width);
+                const path = SvgPath{ .path = data.path };
 
                 try writer.print(
                     \\<path style="{}" d="{}"/>
@@ -194,9 +194,9 @@ pub fn renderStream(allocator: std.mem.Allocator, parser: anytype, writer: anyty
                     try writer.writeAll("</linearGradient>");
                 },
                 .radial => |grad| {
-                    var dx = grad.point_1.x - grad.point_0.x;
-                    var dy = grad.point_1.y - grad.point_0.y;
-                    var r = std.math.sqrt(dx * dx + dy * dy);
+                    const dx = grad.point_1.x - grad.point_0.x;
+                    const dy = grad.point_1.y - grad.point_0.y;
+                    const r = std.math.sqrt(dx * dx + dy * dy);
 
                     try writer.print(
                         \\<radialGradient id="grad{}" gradientUnits="userSpaceOnUse" cx="{d}" cy="{d}" r="{d}">
@@ -328,9 +328,9 @@ const SvgStyleCache = struct {
         }
         const color = self.color_table[i];
 
-        var r: u8 = @intFromFloat(std.math.clamp(255.0 * color.r, 0.0, 255.0));
-        var g = @as(u8, @intFromFloat(std.math.clamp(255.0 * color.g, 0.0, 255.0)));
-        var b = @as(u8, @intFromFloat(std.math.clamp(255.0 * color.b, 0.0, 255.0)));
+        const r: u8 = @intFromFloat(std.math.clamp(255.0 * color.r, 0.0, 255.0));
+        const g = @as(u8, @intFromFloat(std.math.clamp(255.0 * color.g, 0.0, 255.0)));
+        const b = @as(u8, @intFromFloat(std.math.clamp(255.0 * color.b, 0.0, 255.0)));
         try writer.print("{s}:#{X:0>2}{X:0>2}{X:0>2};", .{ prefix, r, g, b });
         if (color.a != 1.0) {
             try writer.print("{s}-opacity:{d};", .{ prefix, color.a });
@@ -343,9 +343,9 @@ const SvgStyleCache = struct {
         }
         const color = self.color_table[i];
 
-        var r: u8 = @intFromFloat(std.math.clamp(255.0 * color.r, 0.0, 255.0));
-        var g: u8 = @intFromFloat(std.math.clamp(255.0 * color.g, 0.0, 255.0));
-        var b = @as(u8, @intFromFloat(std.math.clamp(255.0 * color.b, 0.0, 255.0)));
+        const r: u8 = @intFromFloat(std.math.clamp(255.0 * color.r, 0.0, 255.0));
+        const g: u8 = @intFromFloat(std.math.clamp(255.0 * color.g, 0.0, 255.0));
+        const b = @as(u8, @intFromFloat(std.math.clamp(255.0 * color.b, 0.0, 255.0)));
         try writer.print("{s}#{X:0>2}{X:0>2}{X:0>2}{s}", .{ prefix, r, g, b, postfix });
     }
 };

--- a/src/lib/text.zig
+++ b/src/lib/text.zig
@@ -483,10 +483,10 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                 if (item == .end)
                     break;
 
-                var x = try self.parseNumber();
-                var y = try self.parseNumber();
-                var width = try self.parseNumber();
-                var height = try self.parseNumber();
+                const x = try self.parseNumber();
+                const y = try self.parseNumber();
+                const width = try self.parseNumber();
+                const height = try self.parseNumber();
 
                 try self.expectEnd();
 
@@ -509,8 +509,8 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                 if (item == .end)
                     break;
 
-                var p0 = try self.parsePoint();
-                var p1 = try self.parsePoint();
+                const p0 = try self.parsePoint();
+                const p1 = try self.parsePoint();
 
                 try self.expectEnd();
 
@@ -533,8 +533,8 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                 if (item == .end)
                     break;
 
-                var x = try self.parseNumber();
-                var y = try self.parseNumber();
+                const x = try self.parseNumber();
+                const y = try self.parseNumber();
 
                 try self.expectEnd();
 
@@ -649,11 +649,11 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
             if ((try self.parseInteger(u8)) != 1)
                 return error.UnsupportedVersion;
 
-            var header = try self.parseHeader();
+            const header = try self.parseHeader();
 
             try self.builder.writeHeader(header.width, header.height, header.scale, header.color_encoding, header.coordinate_range);
 
-            var color_table = try self.parseColorTable();
+            const color_table = try self.parseColorTable();
             defer self.allocator.free(color_table);
 
             try self.builder.writeColorTable(color_table);
@@ -668,16 +668,16 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                         const command = try self.parseEnum(tvg.Command);
                         switch (command) {
                             .fill_polygon => {
-                                var style = try self.parseStyle();
+                                const style = try self.parseStyle();
 
-                                var points = try self.readPoints();
+                                const points = try self.readPoints();
                                 defer points.deinit();
 
                                 try self.builder.writeFillPolygon(style, points.items);
                             },
 
                             .fill_rectangles => {
-                                var style = try self.parseStyle();
+                                const style = try self.parseStyle();
                                 var rects = try self.readRectangles();
                                 defer rects.deinit();
 
@@ -685,7 +685,7 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                             },
 
                             .fill_path => {
-                                var style = try self.parseStyle();
+                                const style = try self.parseStyle();
 
                                 var path = try self.readPath();
                                 defer path.deinit();
@@ -694,8 +694,8 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                             },
 
                             .draw_lines => {
-                                var style = try self.parseStyle();
-                                var line_width = try self.parseNumber();
+                                const style = try self.parseStyle();
+                                const line_width = try self.parseNumber();
 
                                 var lines = try self.readLines();
                                 defer lines.deinit();
@@ -704,8 +704,8 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                             },
 
                             .draw_line_loop => {
-                                var style = try self.parseStyle();
-                                var line_width = try self.parseNumber();
+                                const style = try self.parseStyle();
+                                const line_width = try self.parseNumber();
 
                                 var points = try self.readPoints();
                                 defer points.deinit();
@@ -714,8 +714,8 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                             },
 
                             .draw_line_strip => {
-                                var style = try self.parseStyle();
-                                var line_width = try self.parseNumber();
+                                const style = try self.parseStyle();
+                                const line_width = try self.parseNumber();
 
                                 var points = try self.readPoints();
                                 defer points.deinit();
@@ -723,18 +723,18 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                                 try self.builder.writeDrawLineStrip(style, line_width, points.items);
                             },
                             .draw_line_path => {
-                                var style = try self.parseStyle();
-                                var line_width = try self.parseNumber();
+                                const style = try self.parseStyle();
+                                const line_width = try self.parseNumber();
 
-                                var path = try self.readPath();
+                                const path = try self.readPath();
 
                                 try self.builder.writeDrawPath(style, line_width, path.segments);
                             },
 
                             .outline_fill_polygon => {
-                                var fill_style = try self.parseStyle();
-                                var line_style = try self.parseStyle();
-                                var line_width = try self.parseNumber();
+                                const fill_style = try self.parseStyle();
+                                const line_style = try self.parseStyle();
+                                const line_width = try self.parseNumber();
 
                                 var points = try self.readPoints();
                                 defer points.deinit();
@@ -743,9 +743,9 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                             },
 
                             .outline_fill_rectangles => {
-                                var fill_style = try self.parseStyle();
-                                var line_style = try self.parseStyle();
-                                var line_width = try self.parseNumber();
+                                const fill_style = try self.parseStyle();
+                                const line_style = try self.parseStyle();
+                                const line_width = try self.parseNumber();
 
                                 var rects = try self.readRectangles();
                                 defer rects.deinit();
@@ -753,11 +753,11 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8, writer: anytype) 
                                 try self.builder.writeOutlineFillRectangles(fill_style, line_style, line_width, rects.items);
                             },
                             .outline_fill_path => {
-                                var fill_style = try self.parseStyle();
-                                var line_style = try self.parseStyle();
-                                var line_width = try self.parseNumber();
+                                const fill_style = try self.parseStyle();
+                                const line_style = try self.parseStyle();
+                                const line_width = try self.parseNumber();
 
-                                var path = try self.readPath();
+                                const path = try self.readPath();
 
                                 try self.builder.writeOutlineFillPath(fill_style, line_style, line_width, path.segments);
                             },

--- a/src/tools/render.zig
+++ b/src/tools/render.zig
@@ -136,7 +136,7 @@ pub fn main() !u8 {
         var dest_file: std.fs.File = if (write_stdout)
             std.io.getStdIn()
         else blk: {
-            var out_name = cli.options.output orelse try std.mem.concat(allocator, u8, &[_][]const u8{
+            const out_name = cli.options.output orelse try std.mem.concat(allocator, u8, &[_][]const u8{
                 cli.positionals[0][0..(cli.positionals[0].len - std.fs.path.extension(cli.positionals[0]).len)],
                 ".tga",
             });
@@ -146,7 +146,7 @@ pub fn main() !u8 {
         defer if (!read_stdin)
             dest_file.close();
 
-        var writer = dest_file.writer();
+        const writer = dest_file.writer();
         try dumpTga(writer, width, height, image.pixels);
     }
 
@@ -161,20 +161,20 @@ fn dumpTga(src_writer: anytype, width: u16, height: u16, pixels: []const tvg.ren
 
     const image_id = "Hello, TGA!";
 
-    try writer.writeIntLittle(u8, @as(u8, @intCast(image_id.len)));
-    try writer.writeIntLittle(u8, 0); // color map type = no color map
-    try writer.writeIntLittle(u8, 2); // image type = uncompressed true-color image
+    try writer.writeInt(u8, @as(u8, @intCast(image_id.len)), .little);
+    try writer.writeInt(u8, 0, .little); // color map type = no color map
+    try writer.writeInt(u8, 2, .little); // image type = uncompressed true-color image
     // color map spec
-    try writer.writeIntLittle(u16, 0); // first index
-    try writer.writeIntLittle(u16, 0); // length
-    try writer.writeIntLittle(u8, 0); // number of bits per pixel
+    try writer.writeInt(u16, 0, .little); // first index
+    try writer.writeInt(u16, 0, .little); // length
+    try writer.writeInt(u8, 0, .little); // number of bits per pixel
     // image spec
-    try writer.writeIntLittle(u16, 0); // x origin
-    try writer.writeIntLittle(u16, 0); // y origin
-    try writer.writeIntLittle(u16, width); // width
-    try writer.writeIntLittle(u16, height); // height
-    try writer.writeIntLittle(u8, 32); // bits per pixel
-    try writer.writeIntLittle(u8, 8 | 0x20); // 0…3 => alpha channel depth = 8, 4…7 => direction=top left
+    try writer.writeInt(u16, 0, .little); // x origin
+    try writer.writeInt(u16, 0, .little); // y origin
+    try writer.writeInt(u16, width, .little); // width
+    try writer.writeInt(u16, height, .little); // height
+    try writer.writeInt(u8, 32, .little); // bits per pixel
+    try writer.writeInt(u8, 8 | 0x20, .little); // 0…3 => alpha channel depth = 8, 4…7 => direction=top left
 
     try writer.writeAll(image_id);
     try writer.writeAll(""); // color map data \o/

--- a/src/tools/svg2tvgt/svg2tvgt.csproj
+++ b/src/tools/svg2tvgt/svg2tvgt.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject>Application</StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
This commit updates the repo to build with more recent versions of Zig 0.12, namely updating for semantic changes, e.g. enforcing const when values are not mutated, build API changes, generalization of readInt and writeInt, etc. This also updates the zig-args and parser-toolkit dependencies to accommodate.

Additionally, this updates svg2tvgt to build with .NET 6.0 versus 5.0, which is EOL and has been removed out of nixpkgs. This built without any other changes necessary.