### PR TITLE
tools/svg2tvgt: build with .NET 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
           version: v0.11.0
 
       - name: Install dotnet sdk
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: Compile Tools
         run: zig build install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This SDK enables you to work with the [TinyVG](https://tinyvg.tech/) vector grap
 
 ## Building
 
-The SDK is implemented with [Zig](https://ziglang.org/) 0.11.0 and [dotnet 5](https://dotnet.microsoft.com/en-us/).
+The SDK is implemented with [Zig](https://ziglang.org/) 0.11.0 and [dotnet 6](https://dotnet.microsoft.com/en-us/).
 
 To build the SDK (except `svg2tvgt`), do this:
 
@@ -28,18 +28,16 @@ To build `svg2tvgt`, go into the folder `src/tools/svg2tvgt` and do this:
 ```sh-session
 [user@host sdk]$ cd src/tools/svg2tvgt/
 [user@host svg2tvgt]$ dotnet build
-Microsoft (R) Build Engine version 16.11.1+3e40a09f8 for .NET
-Copyright (C) Microsoft Corporation. All rights reserved.
-
+MSBuild version 17.3.2+561848881 for .NET
   Determining projects to restore...
   All projects are up-to-date for restore.
-  svg2tvgt -> /mnt/src/tools/svg2tvgt/bin/Debug/net5.0/svg2tvgt.dll
+  svg2tvgt -> /mnt/src/tools/svg2tvgt/bin/Debug/net6.0/svg2tvgt.dll
 
 Build succeeded.
     0 Warning(s)
     0 Error(s)
 
-Time Elapsed 00:00:01.59
+Time Elapsed 00:00:00.69
 [user@host svg2tvgt]$
 ```
 

--- a/src/tools/svg2tvgt/svg2tvgt.csproj
+++ b/src/tools/svg2tvgt/svg2tvgt.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject>Application</StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
This updates the .NET version in the project file to 6.0.

.NET 5.0 went EOL last year, so it might be tough to build it under the 5.0 framework.

.NET 6.0 is supported until later 2024.