### PR TITLE
tools/svg2tvgt: handle scientific notation in float

### DIFF
--- a/src/tools/svg2tvgt/svg2tvgt.cs
+++ b/src/tools/svg2tvgt/svg2tvgt.cs
@@ -2192,20 +2192,20 @@ public class SvgPathParser
     {
       while (true)
       {
-        c = PeekAny("0123456789.");
+        c = PeekAny("0123456789.eE+-");
         if (c == null)
           return ParseFloat(begin.Slice());
-        AcceptChar("0123456789.");
+        AcceptChar("0123456789.eE+-");
         if (c.Value == '.')
           break;
       }
     }
     while (true)
     {
-      c = PeekAny("0123456789");
+      c = PeekAny("0123456789eE+-");
       if (c == null)
         return ParseFloat(begin.Slice());
-      AcceptChar("0123456789");
+      AcceptChar("0123456789eE+-");
     }
   }
 


### PR DESCRIPTION
This updates the svg2tvgt to handle scientific notation in floating-point values, which can exist, apparently. ;)