### PR TITLE
tvg-render: use bufferedReader for 10x performance boost in parsing

### DIFF
--- a/src/tools/render.zig
+++ b/src/tools/render.zig
@@ -114,6 +114,7 @@ pub fn main() !u8 {
     }
 
     // TODO: Render here
+    var buffered_reader = std.io.bufferedReader(source_file.reader());
 
     var image = try tvg.rendering.renderStream(
         allocator,
@@ -129,7 +130,7 @@ pub fn main() !u8 {
         else
             .inherit,
         @enumFromInt(super_scale),
-        source_file.reader(),
+        buffered_reader.reader(),
     );
     defer image.deinit(allocator);
 


### PR DESCRIPTION
I took a profile of tvg-render and found that reading the file took about 68% of the time.  This was surprising as I would have expected rendering to take longer.  The profile revealed that most of time was spent in the filesystem read syscalls.  I've seen this problem before and the solution in the past has been to use a buffered reader rather than the file reader directly.  After adding the buffered reader the parse time went from about 2 ms to about 200 microseconds (10x improvement).  The total `renderStream` time went from 3.7ms to 1.4ms.

![image](https://github.com/user-attachments/assets/d4bccc2f-b535-4a72-aad5-baa30d84b36f)
![image](https://github.com/user-attachments/assets/499f3fa3-6feb-4501-b23d-7ff3fbf69900)

